### PR TITLE
Add main/exports to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
 	"license": "MIT",
 	"author": "Federico Brigante <me@fregante.com> (https://fregante.com)",
 	"type": "module",
+	"exports": "./index.js",
+	"main": "./index.js",
+	"types": "./index.d.ts",
 	"files": [
 		"index.d.ts",
 		"index.js"
 	],
-	"main": "index.js",
 	"scripts": {
 		"test": "xo && ava"
 	},

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"index.d.ts",
 		"index.js"
 	],
+	"main": "index.js",
 	"scripts": {
 		"test": "xo && ava"
 	},


### PR DESCRIPTION
Hello, there is an annoying warning when compiling with Next 13 after each page visit. `main` needs to be added to `package.json`.

```
(node:3356) [DEP0151] DeprecationWarning: No "main" or "exports" field defined in the package.json for C:\Projects\city-library\next\node_modules\many-keys-map\ resolving the main entry point "index.js", imported from C:\Projects\city-library\next\.next\server\pages\_app.js.
Default "index" lookups for the main are deprecated for ES modules.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Thanks for merging.